### PR TITLE
#8, Life check, UI change, reverse and position get

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # odin-kinesis
-Software package for controlling motors (initially Thorlabs motors) with [odin-control](https://github.com/odin-detector/odin-control).
+Software package for controlling Thorlabs motors with [odin-control](https://github.com/odin-detector/odin-control), using their APT communications protocol.

--- a/src/kinesis/adapter.py
+++ b/src/kinesis/adapter.py
@@ -2,7 +2,7 @@ import logging
 
 from tornado.escape import json_decode
 
-from odin.adapters.adapter import ApiAdapter, ApiAdapterResponse, request_types, response_types
+from odin.adapters.adapter import ApiAdapter, ApiAdapterResponse, request_types, response_types, wants_metadata
 from odin.adapters.parameter_tree import ParameterTreeError
 from odin.util import decode_request_body
 
@@ -30,7 +30,7 @@ class KinesisAdapter(ApiAdapter):
         :return: an ApiAdapterResponse object containing the appropriate response
         """
         try:
-            response = self.kinesis.get(path)
+            response = self.kinesis.get(path, wants_metadata(request))
             status_code = 200
         except ParameterTreeError as e:
             response = {'error': str(e)}

--- a/src/kinesis/controller.py
+++ b/src/kinesis/controller.py
@@ -11,6 +11,7 @@ import time
 import logging
 import json
 
+from kinesis.controllers.baseMotorController import BaseMotorController
 from kinesis.controllers.motController import MotController
 from kinesis.controllers.kim101_controller import KimController
 
@@ -24,7 +25,7 @@ class KinesisController():
     DEBUG = False
 
     # Thread executor used for background tasks
-    executor = futures.ThreadPoolExecutor(max_workers=1)
+    executor = futures.ThreadPoolExecutor(max_workers=2)
 
     def __init__(self, options):
         """Initialise the KinesisAdapter object.
@@ -34,10 +35,11 @@ class KinesisController():
 
         :param kwargs: keyword arguments specifying options
         """
-        self.options = options
         # Options
-        self.bg_await_reply_enable = bool(int(self.options.get('bg_await_reply_enable', 1)))
-        self.bg_await_reply_interval = float(self.options.get('bg_await_reply_interval', 0.5))
+        self.options = options
+        self.bg_tasks_enable = bool(int(self.options.get('bg_tasks_enable', 1)))
+        self.bg_await_reply_interval = float(self.options.get('bg_await_reply_interval', 0.3))
+        self.bg_check_position_interval = float(self.options.get('bg_check_position_interval', 0.5))
         device_config = self.options.get('device_config', 'test/config/devices.json')
 
         self.current_command = None
@@ -45,7 +47,7 @@ class KinesisController():
         self.tree = {}
 
         # Create controller children
-        self.controllers = {}
+        self.controllers: dict[str, BaseMotorController] = {}
         with open(device_config, "r") as file:
             devices = json.load(file)
 
@@ -62,14 +64,25 @@ class KinesisController():
                 else:
                     logging.debug(f"Controller {name} not supported type of controller.")
 
-        # self.param_tree = ParameterTree({
-        #     'bg_task_interval': (lambda: self.bg_await_reply_interval, None),
-        #     'controllers': self.tree
-        # })
-
         logging.debug('KinesisAdapter loaded')
 
     # ------------ background functions ------------
+
+    @run_on_executor
+    def background_check_positions(self):
+        """Background task to check the positions of the motors.
+        This also serves as a 'heartbeat', checking that motors are still connected.
+        """
+        while self.bg_await_reply_enable:  # No need for more than one enable toggle here
+            for controller in self.controllers.values():
+                for name, motor in controller.stages.items():
+                    try:
+                        motor.get_current_position()
+                        # _recv_replies() handles multiple replies, so other thread can handle that
+                    except Exception as e:
+                        logging.error(f"Error checking position for motor {name}: {e}")
+            
+            time.sleep(self.bg_check_position_interval)
 
     @run_on_executor
     def background_await_reply(self):
@@ -83,8 +96,8 @@ class KinesisController():
             for name, controller in self.controllers.items():
                 # Do a queue check for the controller
                 controller._check_reply_queues()
-            
-            # Check every 0.2s
+
+            # Check on interval
             time.sleep(self.bg_await_reply_interval)
 
     def _start_background_task(self):
@@ -96,6 +109,7 @@ class KinesisController():
 
         # Run the background thread task in the thread execution pool
         self.background_await_reply()
+        self.background_check_positions()
 
     def _stop_background_task(self):
         """Stop the background tasks."""

--- a/src/kinesis/controller.py
+++ b/src/kinesis/controller.py
@@ -93,8 +93,14 @@ class KinesisController():
             # Only need to check for replies if there's an active command
 
             # Check every controller
-            for name, controller in self.controllers.items():
+            for controller in self.controllers.values():
                 # Do a queue check for the controller
+                controller._check_command_queues()
+
+            # time.sleep(0.02)  # Was necessary delay previously but did not need repeating in every queue
+
+            # With command queues checked, check for replies
+            for controller in self.controllers.values():
                 controller._check_reply_queues()
 
             # Check on interval

--- a/src/kinesis/controllers/baseMotorController.py
+++ b/src/kinesis/controllers/baseMotorController.py
@@ -30,9 +30,11 @@ class BaseMotorController:
 
         # Create motor children
         for name, details in stages.items():
+            upper_limit = details['upper_limit']
+            lower_limit = details['lower_limit']
             stage_type = details['stage_type']
             if stage_type in ['MTS25-Z8', 'MTS50-Z8']:
-                self.stages[name] = EncoderStage(name, chan_ident, stage_type, self)
+                self.stages[name] = EncoderStage(name, upper_limit, lower_limit, chan_ident, stage_type, self)
             if stage_type in ['PD1VM']:
                 self.stages[name] = PiezoStage(name, chan_ident, stage_type, self)
 

--- a/src/kinesis/controllers/baseMotorController.py
+++ b/src/kinesis/controllers/baseMotorController.py
@@ -26,8 +26,6 @@ class BaseMotorController:
         self._open_serial(port)
 
         self.tree = {}
-
-        self.tree = {}
         chan_ident = 1
 
         # Create motor children
@@ -158,6 +156,9 @@ class BaseMotorController:
 
     def _decode_reply(self, reply: bytearray):
         raise NotImplementedError("Reply decoding must be implemented by the controller subclass.")
+
+    def get_encoder_position(self, motor: BaseMotorStage):
+        raise NotImplementedError("Stage position get must be implemented by controller subclass.")
 
     def _check_reply_queues(self):
         """Check the instant queue to send any commands from it.

--- a/src/kinesis/controllers/baseMotorController.py
+++ b/src/kinesis/controllers/baseMotorController.py
@@ -94,7 +94,6 @@ class BaseMotorController:
         """Receive any available replies."""
         if not self.port_is_open():
             return []
-        time.sleep(0.04)  # Necessary delay for data arrival
         # Fill buffer from serial
         while self.ser.in_waiting > 0:
             self._in_buffer.extend(self.ser.read())
@@ -160,11 +159,8 @@ class BaseMotorController:
     def get_encoder_position(self, motor: BaseMotorStage):
         raise NotImplementedError("Stage position get must be implemented by controller subclass.")
 
-    def _check_reply_queues(self):
-        """Check the instant queue to send any commands from it.
-        Then check for replies, seeing if a response is expected by any motor.
-        If it is, send the next command from that motor's await_queue.
-        """
+    def _check_command_queues(self):
+        """Check the instant queue to send any commands from it."""
         # Send one instant command from the queue, if there is one
         for name, motor in self.stages.items():
             if not motor.instant_queue.empty():
@@ -178,6 +174,10 @@ class BaseMotorController:
                 motor.current_command = cmd_fn.__name__
                 motor.expected_response = exp_rsp['name']
 
+    def _check_reply_queues(self):
+        """Check for replies, seeing if a response is expected by any motor.
+        If it is, send the next command from that motor's await_queue.
+        """
         # Then process replies
         replies = self._recv_reply()
 

--- a/src/kinesis/controllers/motController.py
+++ b/src/kinesis/controllers/motController.py
@@ -68,7 +68,7 @@ class MotController(BaseMotorController):
             )
         else:
             motor.await_queue.put(
-                (MSG.mot_move_jog, {'direction': 0x00})
+                (MSG.mot_move_jog, {'direction': 0x02})
             )
 
     def move_stop(self, motor: EncoderStage):

--- a/src/kinesis/motor_stages/baseMotorStage.py
+++ b/src/kinesis/motor_stages/baseMotorStage.py
@@ -34,7 +34,7 @@ class BaseMotorStage():
             'position': {
                 'home': (lambda: None, self.home),
                 'set_target_pos': (lambda: self.target_position, self.set_target_position),
-                'current_pos': (lambda: self.get_current_position(), None),
+                'current_pos': (lambda: self.current_position, None),
                 'stop': (lambda: None, self.stop)
             },
             'command': {

--- a/src/kinesis/motor_stages/baseMotorStage.py
+++ b/src/kinesis/motor_stages/baseMotorStage.py
@@ -26,6 +26,8 @@ class BaseMotorStage():
         self.current_position = 0
         self.target_position = None
 
+        self.reverse_jog = False
+
         # Cannot compare functions as a queue priority tool, as all but stop are '1'. This iterator
         # will increment each so that simple function-in-queue structure can stay
         self._queue_counter = itertools.count()
@@ -45,6 +47,10 @@ class BaseMotorStage():
         }
 
     # ------------ Positional functions ------------
+
+    def reverse_jog_direction(self, rev):
+        """Reverse (True) or unreverse (False) the direction of the jog."""
+        self.reverse_jog = bool(rev)
 
     def get_current_position(self):
         """Get the current position of this motor."""

--- a/src/kinesis/motor_stages/encoderStages.py
+++ b/src/kinesis/motor_stages/encoderStages.py
@@ -58,7 +58,8 @@ class EncoderStage(BaseMotorStage):
             'accel': (lambda: self.jog_accel, self.set_jog_accel),
             'max_vel': (lambda: self.jog_max_vel, self.set_jog_max_vel),
             'stop_mode': (lambda: self.jog_stop_mode, self.set_jog_stop_mode),
-            'step': (lambda: None, self.jog)
+            'step': (lambda: None, self.jog),
+            'reverse': (lambda: self.reverse_jog, self.reverse_jog_direction)
         }
         self.tree['limits'] = {
             'upper_limit': (lambda: self.upper_limit, self.set_upper_limit),
@@ -119,9 +120,12 @@ class EncoderStage(BaseMotorStage):
         """
         direction = bool(direction)
 
+        if self.reverse_jog:
+            direction = not direction
+
         # Check if step moves beyond limit
         sign = 1 if direction else -1
-        predicted_pos = self.current_pos + self.jog_step_size*sign
+        predicted_pos = self.current_position + self.jog_step_size*sign
         if (self.lower_limit <= predicted_pos) or (predicted_pos <= self.upper_limit):
             self.controller.move_jog(direction, self)
 

--- a/src/kinesis/motor_stages/encoderStages.py
+++ b/src/kinesis/motor_stages/encoderStages.py
@@ -25,7 +25,7 @@ class EncoderStage(BaseMotorStage):
     # ==> VEL (PRM1-Z8) = 6.2942e4 x Vel
     # ==> ACC (PRM1-Z8) = 14.6574 x Acc
 
-    def __init__(self, name, chan_ident: int=1, stage_type: str=None, controller=None, destination=0x50):
+    def __init__(self, name, upper_limit, lower_limit, chan_ident: int=1, stage_type: str=None, controller=None, destination=0x50):
         # Initialise properties and tree of base motor stage
         super().__init__(name, chan_ident, stage_type, controller, destination)
 
@@ -45,6 +45,9 @@ class EncoderStage(BaseMotorStage):
         self.jog_max_vel = 1  # mm/s
         self.jog_stop_mode = 0x02  # Profiled, 0x01 is abrupt
 
+        self.upper_limit = upper_limit
+        self.lower_limit = lower_limit
+
     def initialize(self):
         """Post-init adapter function to get required parameters."""
         logging.debug(f"Initialize: updating tree for Encoder Stage {self.name}.")
@@ -56,6 +59,10 @@ class EncoderStage(BaseMotorStage):
             'max_vel': (lambda: self.jog_max_vel, self.set_jog_max_vel),
             'stop_mode': (lambda: self.jog_stop_mode, self.set_jog_stop_mode),
             'step': (lambda: None, self.jog)
+        }
+        self.tree['limits'] = {
+            'upper_limit': (lambda: self.upper_limit, self.set_upper_limit),
+            'lower_limit': (lambda: self.lower_limit, self.set_lower_limit)
         }
         self.controller.get_jogparams(self)
 
@@ -91,9 +98,18 @@ class EncoderStage(BaseMotorStage):
         pos = float(pos)
         self.target_position = pos
 
-        if self.target_position != self.current_position:
+        if (self.target_position != self.current_position) and (
+            self.lower_limit <= self.target_position or self.target_position <= self.upper_limit):
             pos = self.val_to_enc(pos, ValueType.POS)
             self.controller.move(pos, self)
+
+    def set_upper_limit(self, lim):
+        """Set the upper limit position of the stage in mm."""
+        self.upper_limit = lim
+
+    def set_lower_limit(self, lim):
+        """Set the upper limit position of the stage in mm."""
+        self.lower_limit = lim
 
     # ------------ Jog functions ------------
 
@@ -102,7 +118,12 @@ class EncoderStage(BaseMotorStage):
         :param bool direction: True (forward), False (back).
         """
         direction = bool(direction)
-        self.controller.move_jog(direction, self)
+
+        # Check if step moves beyond limit
+        sign = 1 if direction else -1
+        predicted_pos = self.current_pos + self.jog_step_size*sign
+        if (self.lower_limit <= predicted_pos) or (predicted_pos <= self.upper_limit):
+            self.controller.move_jog(direction, self)
 
     def set_jog_mode(self, value):
         """Set the jog mode then update the params through the controller.

--- a/test/config/devices.json
+++ b/test/config/devices.json
@@ -1,21 +1,13 @@
 {
-    "sample": {
-        "device_type": "KIM101",
-        "port": "/dev/ttyUSB2",
-        "bay_system": false,
-        "stages":{
-            "sample_mover": {
-                "stage_type": "PD1VM"
-            }
-        }
-    },
     "furnace": {
         "device_type": "KDC101",
-        "port": "/dev/ttyUSB3",
+        "port": "/dev/ttyUSB0",
         "bay_system": false,
         "stages":{
             "heater_a": {
-                "stage_type": "MTS50-Z8"
+                "stage_type": "MTS50-Z8",
+                "upper_limit": 10,
+                "lower_limit": -10
             }
         }
     }

--- a/test/config/kinesis.cfg
+++ b/test/config/kinesis.cfg
@@ -12,7 +12,8 @@ logging = debug
 [adapter.kinesis]
 module = kinesis.adapter.KinesisAdapter
 # Background task parameters
-bg_await_reply_enable = 1
-bg_await_reply_interval = 0.2
+bg_tasks_enable = 1
+bg_await_reply_interval = 0.3
+bg_check_position_interval = 0.5
 
 device_config = test/config/devices.json

--- a/test/config/kinesis.cfg
+++ b/test/config/kinesis.cfg
@@ -1,7 +1,7 @@
 [server]
 debug_mode  = 1
 http_port   = 8888
-http_addr   = 192.168.0.22
+http_addr   = 
 static_path = test/static
 adapters    = kinesis
 enable_cors = true

--- a/test/static/kinesis-react/src/components/EncoderStage.jsx
+++ b/test/static/kinesis-react/src/components/EncoderStage.jsx
@@ -7,6 +7,7 @@ import Button from 'react-bootstrap/esm/Button';
 
 import InputGroup from 'react-bootstrap/InputGroup';
 import Form from 'react-bootstrap/Form';
+import Accordion from 'react-bootstrap/Accordion';
 
 const EndPointFormControl = WithEndpoint(Form.Control);
 const EndPointToggle = WithEndpoint(ToggleSwitch);
@@ -23,133 +24,157 @@ function EncoderStage(props){
   return (
     <TitleCard title={"Motor "+name}>
     <Row>
-      <Col xs={7}>
+      <Col xs={3}>
         <Row>
-          <Col xs={6}>
-            <InputGroup>
-              <InputGroup.Text>Pos.</InputGroup.Text>
-                <InputGroup.Text>{data.position.current_pos}</InputGroup.Text>
-            </InputGroup>
-          </Col>
-          <Col xs={6}>
-            <InputGroup>
-              <InputGroup.Text>Target</InputGroup.Text>
-                <Form.Control
-                  type="number"
-                  value={targetPosition}
-                  event_type="enter"
-                  onChange={handleTargetChange}
-                  disabled={data.moving}
-                >
-                </Form.Control>
-                <EndPointButton
-                  endpoint={kinesisEndPoint}
-                  fullpath={dataPath+"/position/set_target_pos"}
-                  event_type="click"
-                  value={targetPosition}
-                >
-                  Move
-                </EndPointButton>
-
-            </InputGroup>
+          <Col>
+            <label>Position (mm)</label>
           </Col>
         </Row>
-        <Row className='mt-3'>
-          <Col>
-            details
-          </Col>
-          <Col>
-          Jog settings
-            <InputGroup>
-              <InputGroup.Text>
-                Step
-              </InputGroup.Text>
-              <EndPointFormControl
-                  endpoint={kinesisEndPoint}
-                  fullpath={dataPath+"/jog/step_size"}
-                  type="number"
-                  event_type="enter"
-                  value={data.jog.step_size}
-              />
-            </InputGroup>
-            <InputGroup>
-              <InputGroup.Text>
-                Max vel.
-              </InputGroup.Text>
-              <EndPointFormControl
-                  endpoint={kinesisEndPoint}
-                  fullpath={dataPath+"/jog/max_vel"}
-                  type="number"
-                  event_type="enter"
-                  value={data.jog.max_vel}
-              />
-            </InputGroup>
-            <InputGroup>
-              <InputGroup.Text>
-                Accel.
-              </InputGroup.Text>
-              <EndPointFormControl
-                  endpoint={kinesisEndPoint}
-                  fullpath={dataPath+"/jog/accel"}
-                  type="number"
-                  event_type="enter"
-                  value={data.jog.accel}
-              />
-            </InputGroup>
-          </Col>
+        <Row>
+          <InputGroup>
+            <InputGroup.Text style={{width:100}}>Current: </InputGroup.Text>
+              <InputGroup.Text>{data.position.current_pos}</InputGroup.Text>
+          </InputGroup>
+        </Row>
+        <Row>
+          <InputGroup>
+            <InputGroup.Text style={{width:100}}>Target:</InputGroup.Text>
+              <Form.Control
+                type="number"
+                value={targetPosition}
+                event_type="enter"
+                onChange={handleTargetChange}
+                disabled={data.moving}
+              >
+              </Form.Control>
+          </InputGroup>
+        </Row>
+        <Row>
+          <EndPointButton
+            endpoint={kinesisEndPoint}
+            fullpath={dataPath+"/position/set_target_pos"}
+            event_type="click"
+            value={targetPosition}
+          >
+            Move to target
+          </EndPointButton>
         </Row>
       </Col>
-      <Col xs={5}>
-        <Row>
-          <Col xs={6} className='mr-3'>
-            <Row>
-              <EndPointButton
-                endpoint={kinesisEndPoint}
-                fullpath={dataPath+"/jog/step"}
-                event_type="click"
-                value={true}
-              >
-                Step forward
-              </EndPointButton>
-            </Row>
-            <Row className='mt-3'>
+      <Col xs={4}>
+        <Row className="mb-3">
+          <Col>
             <EndPointButton
-                endpoint={kinesisEndPoint}
-                fullpath={dataPath+"/jog/step"}
-                event_type="click"
-                value={false}
+              endpoint={kinesisEndPoint}
+              fullpath={dataPath + "/jog/step"}
+              event_type="click"
+              value={true}
+            >
+              Step forward
+            </EndPointButton>
+          </Col>
+          <Col>
+            <EndPointButton
+              endpoint={kinesisEndPoint}
+              fullpath={dataPath + "/jog/step"}
+              event_type="click"
+              value={false}
             >
               Step backward
             </EndPointButton>
-            </Row>
           </Col>
-          <Col xs={6} className="ml-2">
-            <Row>
-              <EndPointButton
-                endpoint={kinesisEndPoint}
-                fullpath={dataPath+"/position/home"}
-                event_type="click"
-                value={true}
-              >Home</EndPointButton>
-            </Row>
-            <Row className='mt-3'>
-              <EndPointButton
-                endpoint={kinesisEndPoint}
-                fullpath={dataPath+"/position/stop"}
-                event_type="click"
-                variant="danger"
-                value={true}
-              >
-                Stop movement
-              </EndPointButton>
-            </Row>
-            <Row>
-              Identify
-            </Row>
-            <Row>
-              etc.
-            </Row>
-          </Col>
+        </Row>
+
+        <Accordion>
+          <Accordion.Item eventKey="0">
+            <Accordion.Header>Jog/step settings</Accordion.Header>
+            <Accordion.Body>
+              <Row>
+                <Col>
+                  <Form.Check
+                    type="checkbox"
+                    label="Reverse forward/back"
+                  />
+                </Col>
+              </Row>
+              <InputGroup className="mt-2">
+                <InputGroup.Text>Step</InputGroup.Text>
+                <EndPointFormControl
+                  endpoint={kinesisEndPoint}
+                  fullpath={dataPath + "/jog/step_size"}
+                  type="number"
+                  event_type="enter"
+                  value={data.jog.step_size}
+                />
+              </InputGroup>
+              <InputGroup className="mt-2">
+                <InputGroup.Text>Max vel.</InputGroup.Text>
+                <EndPointFormControl
+                  endpoint={kinesisEndPoint}
+                  fullpath={dataPath + "/jog/max_vel"}
+                  type="number"
+                  event_type="enter"
+                  value={data.jog.max_vel}
+                />
+              </InputGroup>
+              <InputGroup className="mt-2">
+                <InputGroup.Text>Accel.</InputGroup.Text>
+                <EndPointFormControl
+                  endpoint={kinesisEndPoint}
+                  fullpath={dataPath + "/jog/accel"}
+                  type="number"
+                  event_type="enter"
+                  value={data.jog.accel}
+                />
+              </InputGroup>
+            </Accordion.Body>
+          </Accordion.Item>
+        </Accordion>
+      </Col>
+      <Col xs={3}>
+        <Row>
+          <InputGroup className="mt-2">
+            <InputGroup.Text>Upper limit (mm)</InputGroup.Text>
+            <EndPointFormControl
+              endpoint={kinesisEndPoint}
+              fullpath={dataPath + "/limits/upper_limit"}
+              type="number"
+              event_type="enter"
+              value={data.limits.upper_limit}
+            />
+          </InputGroup>
+          <InputGroup className="mt-2">
+            <InputGroup.Text>Lower limit (mm)</InputGroup.Text>
+            <EndPointFormControl
+              endpoint={kinesisEndPoint}
+              fullpath={dataPath + "/limits/lower_limit"}
+              type="number"
+              event_type="enter"
+              value={data.limits.lower_limit}
+            />
+          </InputGroup>
+        </Row>
+      </Col>
+      <Col xs={2}>
+        <Row>
+          <EndPointButton
+            endpoint={kinesisEndPoint}
+            fullpath={dataPath+"/position/home"}
+            event_type="click"
+            value={true}
+          >
+             Home
+          </EndPointButton>
+        </Row>
+        <Row className="mt-3">
+          <EndPointButton
+            endpoint={kinesisEndPoint}
+            fullpath={dataPath+"/position/stop"}
+            event_type="click"
+            variant="danger"
+            value={true}
+          >
+            Stop movement
+          </EndPointButton>
         </Row>
       </Col>
     </Row>

--- a/test/static/kinesis-react/src/components/EncoderStage.jsx
+++ b/test/static/kinesis-react/src/components/EncoderStage.jsx
@@ -24,31 +24,7 @@ function EncoderStage(props){
   return (
     <TitleCard title={"Motor "+name}>
     <Row>
-      <Col xs={3}>
-        <Row>
-          <Col>
-            <label>Position (mm)</label>
-          </Col>
-        </Row>
-        <Row>
-          <InputGroup>
-            <InputGroup.Text style={{width:100}}>Current: </InputGroup.Text>
-              <InputGroup.Text>{data.position.current_pos}</InputGroup.Text>
-          </InputGroup>
-        </Row>
-        <Row>
-          <InputGroup>
-            <InputGroup.Text style={{width:100}}>Target:</InputGroup.Text>
-              <Form.Control
-                type="number"
-                value={targetPosition}
-                event_type="enter"
-                onChange={handleTargetChange}
-                disabled={data.moving}
-              >
-              </Form.Control>
-          </InputGroup>
-        </Row>
+      <Col xs={4}>
         <Row>
           <EndPointButton
             endpoint={kinesisEndPoint}
@@ -59,9 +35,7 @@ function EncoderStage(props){
             Move to target
           </EndPointButton>
         </Row>
-      </Col>
-      <Col xs={4}>
-        <Row className="mb-3">
+        <Row className="mt-3">
           <Col>
             <EndPointButton
               endpoint={kinesisEndPoint}
@@ -83,54 +57,51 @@ function EncoderStage(props){
             </EndPointButton>
           </Col>
         </Row>
-
-        <Accordion>
-          <Accordion.Item eventKey="0">
-            <Accordion.Header>Jog/step settings</Accordion.Header>
-            <Accordion.Body>
-              <Row>
-                <Col>
-                  <Form.Check
-                    type="checkbox"
-                    label="Reverse forward/back"
-                  />
-                </Col>
-              </Row>
-              <InputGroup className="mt-2">
-                <InputGroup.Text>Step</InputGroup.Text>
-                <EndPointFormControl
-                  endpoint={kinesisEndPoint}
-                  fullpath={dataPath + "/jog/step_size"}
-                  type="number"
-                  event_type="enter"
-                  value={data.jog.step_size}
-                />
-              </InputGroup>
-              <InputGroup className="mt-2">
-                <InputGroup.Text>Max vel.</InputGroup.Text>
-                <EndPointFormControl
-                  endpoint={kinesisEndPoint}
-                  fullpath={dataPath + "/jog/max_vel"}
-                  type="number"
-                  event_type="enter"
-                  value={data.jog.max_vel}
-                />
-              </InputGroup>
-              <InputGroup className="mt-2">
-                <InputGroup.Text>Accel.</InputGroup.Text>
-                <EndPointFormControl
-                  endpoint={kinesisEndPoint}
-                  fullpath={dataPath + "/jog/accel"}
-                  type="number"
-                  event_type="enter"
-                  value={data.jog.accel}
-                />
-              </InputGroup>
-            </Accordion.Body>
-          </Accordion.Item>
-        </Accordion>
+        <Row className='mt-3'>
+          <EndPointButton
+            endpoint={kinesisEndPoint}
+            fullpath={dataPath+"/position/home"}
+            event_type="click"
+            value={true}
+          >
+             Home
+          </EndPointButton>
+        </Row>
+        <Row className="mt-3">
+          <EndPointButton
+            endpoint={kinesisEndPoint}
+            fullpath={dataPath+"/position/stop"}
+            event_type="click"
+            variant="danger"
+            value={true}
+          >
+            Stop movement
+          </EndPointButton>
+        </Row>
       </Col>
-      <Col xs={3}>
+      <Col xs={4}>
+        <Row>
+          <Col>
+            <label>Position (mm)</label>
+          </Col>
+        </Row>
+        <Row>
+          <InputGroup>
+            <InputGroup.Text style={{width:100}}>Current: </InputGroup.Text>
+              <InputGroup.Text>{data.position.current_pos}</InputGroup.Text>
+
+            <InputGroup.Text style={{width:100}}>Target:</InputGroup.Text>
+              <Form.Control
+                type="number"
+                value={targetPosition}
+                event_type="enter"
+                onChange={handleTargetChange}
+                disabled={data.moving}
+              >
+              </Form.Control>
+          </InputGroup>
+        </Row>
+
         <Row>
           <InputGroup className="mt-2">
             <InputGroup.Text>Upper limit (mm)</InputGroup.Text>
@@ -154,27 +125,53 @@ function EncoderStage(props){
           </InputGroup>
         </Row>
       </Col>
-      <Col xs={2}>
-        <Row>
-          <EndPointButton
-            endpoint={kinesisEndPoint}
-            fullpath={dataPath+"/position/home"}
-            event_type="click"
-            value={true}
-          >
-             Home
-          </EndPointButton>
-        </Row>
-        <Row className="mt-3">
-          <EndPointButton
-            endpoint={kinesisEndPoint}
-            fullpath={dataPath+"/position/stop"}
-            event_type="click"
-            variant="danger"
-            value={true}
-          >
-            Stop movement
-          </EndPointButton>
+      <Col xs={4}>
+        <Row className='mt-2'>
+          <Accordion >
+            <Accordion.Item eventKey="0">
+              <Accordion.Header>Jog/step settings</Accordion.Header>
+              <Accordion.Body>
+                <Row>
+                  <Col>
+                    <Form.Check
+                      type="checkbox"
+                      label="Reverse forward/back"
+                    />
+                  </Col>
+                </Row>
+                <InputGroup className="mt-2">
+                  <InputGroup.Text>Step</InputGroup.Text>
+                  <EndPointFormControl
+                    endpoint={kinesisEndPoint}
+                    fullpath={dataPath + "/jog/step_size"}
+                    type="number"
+                    event_type="enter"
+                    value={data.jog.step_size}
+                  />
+                </InputGroup>
+                <InputGroup className="mt-2">
+                  <InputGroup.Text>Max vel.</InputGroup.Text>
+                  <EndPointFormControl
+                    endpoint={kinesisEndPoint}
+                    fullpath={dataPath + "/jog/max_vel"}
+                    type="number"
+                    event_type="enter"
+                    value={data.jog.max_vel}
+                  />
+                </InputGroup>
+                <InputGroup className="mt-2">
+                  <InputGroup.Text>Accel.</InputGroup.Text>
+                  <EndPointFormControl
+                    endpoint={kinesisEndPoint}
+                    fullpath={dataPath + "/jog/accel"}
+                    type="number"
+                    event_type="enter"
+                    value={data.jog.accel}
+                  />
+                </InputGroup>
+              </Accordion.Body>
+            </Accordion.Item>
+          </Accordion>
         </Row>
       </Col>
     </Row>

--- a/test/static/kinesis-react/src/components/EncoderStage.jsx
+++ b/test/static/kinesis-react/src/components/EncoderStage.jsx
@@ -10,7 +10,7 @@ import Form from 'react-bootstrap/Form';
 import Accordion from 'react-bootstrap/Accordion';
 
 const EndPointFormControl = WithEndpoint(Form.Control);
-const EndPointToggle = WithEndpoint(ToggleSwitch);
+const EndPointFormCheck = WithEndpoint(Form.Check);
 const EndPointButton = WithEndpoint(Button);
 
 function EncoderStage(props){
@@ -133,10 +133,15 @@ function EncoderStage(props){
               <Accordion.Body>
                 <Row>
                   <Col>
-                    <Form.Check
-                      type="checkbox"
-                      label="Reverse forward/back"
-                    />
+                    <EndPointButton
+                      endpoint={kinesisEndPoint}
+                      fullpath={dataPath+"/jog/reverse"}
+                      value={data.jog.reverse ? false : true}
+                      event_type="click"
+                      text="reverse forward/back"
+                    >
+                      {data.jog.reverse ? "Unreverse" : "Reverse"} forward/back
+                    </EndPointButton>
                   </Col>
                 </Row>
                 <InputGroup className="mt-2">


### PR DESCRIPTION
PR to address some feedback from ESRF beamtime and also to implement some minor features for the 2025 Diamond beamtime.

## Issues Approached

Closes #8, issue is resolved in that there is a lifesign check, position getting is moved to its own background task, and the UI has been adjusted somewhat with a couple of additional features

## Changes Made

~ Position getting moved from tree to background task to avoid client-dependent load
+ Jog direction fixed
~ Split queue-processing background task to avoid previously-necessary sleep in serial reading
+ UI redesigned to be closer to collaborator vision pending potential, more significant, future work
+ Upper/lower positional limits added for absolute move and jog moves
+ Metadata added to adapter for future react update compatibility
+ Reverse jog forward/backward button added